### PR TITLE
Ro schmi 2020 04 26

### DIFF
--- a/software/tinyclr/tutorials/ethernet.md
+++ b/software/tinyclr/tutorials/ethernet.md
@@ -107,7 +107,7 @@ static void Enc28Test()
         SpiNetworkCommunicationInterfaceSettings();
 
     var cs = GHIElectronics.TinyCLR.Devices.Gpio.GpioController.GetDefault().
-        OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PD3);
+        OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PG12);
 
     var settings = new GHIElectronics.TinyCLR.Devices.Spi.SpiConnectionSettings()
     {
@@ -125,12 +125,16 @@ static void Enc28Test()
     networkCommunicationInterfaceSettings.GpioApiName =
         GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.Id;
 
+    
     networkCommunicationInterfaceSettings.SpiSettings = settings;
-    networkCommunicationInterfaceSettings.InterruptPin = SC20100.GpioPin.PC5;
+    networkCommunicationInterfaceSettings.InterruptPin = GHIElectronics.TinyCLR.Devices.Gpio.GpioController.GetDefault().
+        OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PG6);
     networkCommunicationInterfaceSettings.InterruptEdge = GpioPinEdge.FallingEdge;
     networkCommunicationInterfaceSettings.InterruptDriveMode = GpioPinDriveMode.InputPullUp;
-    networkCommunicationInterfaceSettings.ResetPin = SC20100.GpioPin.PD4;
+    networkCommunicationInterfaceSettings.ResetPin = GHIElectronics.TinyCLR.Devices.Gpio.GpioController.GetDefault().
+        OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PI8);
     networkCommunicationInterfaceSettings.ResetActiveState = GpioPinValue.Low;
+
 
     networkInterfaceSetting.Address = new IPAddress(new byte[] { 192, 168, 1, 122 });
     networkInterfaceSetting.SubnetMask = new IPAddress(new byte[] { 255, 255, 255, 0 });

--- a/software/tinyclr/tutorials/ethernet.md
+++ b/software/tinyclr/tutorials/ethernet.md
@@ -90,7 +90,7 @@ private static void NetworkController_NetworkAddressChanged
 
 ## ENC28J60
 
-This example uses the ENC28J60 click on our SC20100S Dev Board.
+This example uses the ENC28J60 click on our SC20260D Dev Board.
 
 >[!TIP]
 >Needed Nugets: GHIElectronics.TinyCLR.Devices.Network, GHIElectronics.TinyCLR.Devices.Gpio, GHIElectronics.TinyCLR.Devices.Spi, GHIElectronics.TinyCLR.Pins

--- a/software/tinyclr/tutorials/wifi.md
+++ b/software/tinyclr/tutorials/wifi.md
@@ -11,7 +11,7 @@ This example uses the FEZ Portal with its built in ATWINC1500 WiFi module.
 
 ```cs
 static void Wifi_Example() {
-            var enablePin = GpioController.GetDefault().OpenPin(SC20260.GpioPin.PA8);
+            var enablePin = GpioController.GetDefault().OpenPin(SC20260.GpioPin.PI0);
 
             enablePin.SetDriveMode(GpioPinDriveMode.Output);
             enablePin.Write(GpioPinValue.High);
@@ -20,7 +20,7 @@ static void Wifi_Example() {
                 new SpiNetworkCommunicationInterfaceSettings();
 
             var cs = GHIElectronics.TinyCLR.Devices.Gpio.GpioController.GetDefault().
-                OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PA6);
+                OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PG12);
 
             var settings = new GHIElectronics.TinyCLR.Devices.Spi.SpiConnectionSettings() {
                 ChipSelectLine = cs,
@@ -39,11 +39,11 @@ static void Wifi_Example() {
 
             networkCommunicationInterfaceSettings.SpiSettings = settings;
             networkCommunicationInterfaceSettings.InterruptPin = GHIElectronics.TinyCLR.Devices.Gpio.GpioController.GetDefault().
-                OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PF10);
+                OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PG6);
             networkCommunicationInterfaceSettings.InterruptEdge = GpioPinEdge.FallingEdge;
             networkCommunicationInterfaceSettings.InterruptDriveMode = GpioPinDriveMode.InputPullUp;
             networkCommunicationInterfaceSettings.ResetPin = GHIElectronics.TinyCLR.Devices.Gpio.GpioController.GetDefault().
-                OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PF8);
+                OpenPin(GHIElectronics.TinyCLR.Pins.SC20260.GpioPin.PI8);
             networkCommunicationInterfaceSettings.ResetActiveState = GpioPinValue.Low;
 
             var networkController = NetworkController.FromName
@@ -99,7 +99,7 @@ static void Wifi_Example() {
 > There is an enable pin which needs to be pulled high on the WiFI 7 click module. 
 
 ```cs
-var enablePin = GpioController.GetDefault().OpenPin(SC20100.GpioPin.PA15);
+var enablePin = GpioController.GetDefault().OpenPin(SC20260.GpioPin.PI0);
             
 enablePin.SetDriveMode(GpioPinDriveMode.Output);
 enablePin.Write(GpioPinValue.High);


### PR DESCRIPTION
GPIO Pins used in the last version of the tutorials Ethernet Enc28 and WiFi didn't match the correct pins on my SC20260D board. The changes of this pull request contain the correct pins (as I think).