### PR TITLE
Can

### DIFF
--- a/software/tinyclr/tutorials/can.md
+++ b/software/tinyclr/tutorials/can.md
@@ -35,7 +35,7 @@ The CAN calculator needs the microcontroller's CAN clock speed. For the SITCore 
 Filters can be set to automatically accept or ignore messages based on their arbitration ID.
 
 > [!Tip]
-> SITCore hardware supports up to 128 filter slots; however, each extended ID uses 2 slots.
+>Each CAN channel supports up to 64 standard IDs and 32 Extended IDs
 
 ### Range Filter
 `AddRangeFilter()` allows you to set a range of arbitration IDs that will be accepted as valid messages. Messages with arbitration IDs outside of this range will be ignored. You can add more than one range filter. In the sample code below, the range filters will accept messages with arbitration IDs ranging from `0x12` to `0x20` and also between `0x500` and `0x1000` inclusive.

--- a/software/tinyclr/tutorials/device-info.md
+++ b/software/tinyclr/tutorials/device-info.md
@@ -1,20 +1,34 @@
-# Device Info
+# Device Information
 ---
 
-## Device name
-Dynamically configure your system through these services that acquire information the device, such as Unique ID, debug interface, hardware type and version.
+Dynamically configure your system through these services that acquire `DeviceInformation`.
 
+Returns devices `UniqueId`
 ```cs
-// device unique ID
 var deviceId = DeviceInformation.UniqueId;
-// show the device name, such as SC20260
-Debug.WriteLine(DeviceInformation.DeviceName);
-// detect what debug intrface is in use
-else if (DeviceInformation.DebugInterface == DebugInterface.Usb)
-   Debug.WriteLine("Debug is in usb mode");
 ```
 
-You can also get manufactures name with the code below. 
+Returns `DeviceName`.
+```cs
+Debug.WriteLine(DeviceInformation.DeviceName);
+```
+
+Returns devices firmware `Version`.
+```cs
+var major = (ushort)((DeviceInformation.Version >> 48) & 0xFFFF);
+var minor = (ushort)((DeviceInformation.Version >> 32) & 0xFFFF);
+var build = (ushort)((DeviceInformation.Version >> 16) & 0xFFFF);
+var revision = (ushort)((DeviceInformation.Version >> 0) & 0xFFFF);
+Debug.WriteLine(major +"."+ minor +"."+ build +"."+ revision);
+```
+
+Detects which `DebugInterface` is in use.
+```cs
+if (DeviceInformation.DebugInterface == DebugInterface.Usb)
+   Debug.WriteLine("Debug is in USB mode");
+```
+
+Returns `ManufacturerName` information.  
 ```cs
 Debug.WriteLine(DeviceInformation.ManufacturerName);
 ```


### PR DESCRIPTION
Updated CAN tip from 128 standard IDs to 64 standard and 32 extended.