### PR TITLE
SetPersistDeviceName => SetDeviceName

### DIFF
--- a/software/tinyclr/tutorials/device-info.md
+++ b/software/tinyclr/tutorials/device-info.md
@@ -63,7 +63,7 @@ Debug.WriteLine(DeviceInformation.ManufacturerName);
 
 ## Device Name
 
-Devices have a default name that they ship with. This can be read using `DeviceInformation.DeviceName`. This name also shows on the USB debug interface. The name can changed only once through `DeviceInformation.SetPersistDeviceName("New Device Name")`. Once set, a complete device erase is required before changing the name again.
+Devices have a default name that they ship with. This can be read using `DeviceInformation.DeviceName`. This name also shows on the USB debug interface. The name can changed only once through `DeviceInformation.SetDeviceName("New Device Name")`. Once set, a complete device erase is required before changing the name again.
 
 > [!TIP]
 > Since Windows caches the name when loading the driver, Windows `Device Manager` will still show the old name. Simply right-click on the device and uninstall the driver. The next time it installs the drivers it will update with the new name.


### PR DESCRIPTION
DeviceInformation does not appear to contain a SetPersistDeviceName method.
Replaced with the available SetDeviceName method.