### PR TITLE
Fix code of Gpio "Digital Inputs/Digital Inputs Events"

### DIFF
--- a/endpoint/tutorials/gpio.md
+++ b/endpoint/tutorials/gpio.md
@@ -60,8 +60,8 @@ var button = new GpioController(PinNumberingScheme.Logical, buttonDriver);
 button.OpenPin(buttonPin, PinMode.InputPullUp);
 
 while (true){
-    if (button.Read(pin) == PinValue.Low){
-        Console.Writeline("Button is pressed")
+    if (button.Read(buttonPin) == PinValue.Low) {
+        Console.WriteLine("Button is pressed");
     }
     Thread.Sleep(10);  
 }
@@ -86,7 +86,7 @@ var button = new GpioController(PinNumberingScheme.Logical, buttonDriver);
 
 button.OpenPin(buttonPin, PinMode.InputPullUp);
 button.RegisterCallbackForPinValueChangedEvent(
-    pin,
+    buttonPin,
     PinEventTypes.Falling | PinEventTypes.Rising,
     OnPinEvent);
 


### PR DESCRIPTION
**Description**
This PR fixes variable naming inconsistency and a minor typo in the codebase. The `Digital Inputs` and `Digital Inputs Events` sections now correctly use `buttonPin `instead of `pin`. Additionally, the letter 'L' in `Console.WriteLine` is capitalized for consistency.

**Changes Made**
Corrected variable naming from `pin` to `buttonPin` in relevant sections.
Capitalized 'L' in `Console.WriteLine`.